### PR TITLE
Fixes an error

### DIFF
--- a/src/main/java/me/kkdevs/broadcaster/Loader.java
+++ b/src/main/java/me/kkdevs/broadcaster/Loader.java
@@ -54,7 +54,7 @@ public class Loader extends PluginBase {
         return text
                 .replace("%player_name%", player.getName())
                 .replace("%player_displayname%", player.getDisplayName())
-                .replace("%player_ping%", Integer.toString(player.getPing()))
+                .replace("%player_ping%", (player.isOnline() ? Integer.toString(player.getPing()) : "null"))
                 .replace("%player_health%", Float.toString(player.getHealth()))
                 .replace("%player_maxhealth%", Integer.toString(player.getMaxHealth()))
                 .replace("%player_x%", Integer.toString(player.getFloorX()))


### PR DESCRIPTION
Fixes an error that occurs when the player quits.
```
03:34:08 [ERROR] Throwing
cn.nukkit.utils.EventException: null
        at cn.nukkit.plugin.MethodEventExecutor.execute(MethodEventExecutor.java:34) ~[nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:56) ~[nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.plugin.PluginManager.callEvent(PluginManager.java:546) [nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.Player.close(Player.java:3564) [nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.Player.close(Player.java:3550) [nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.network.RakNetInterface.closeSession(RakNetInterface.java:84) [nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.raknet.server.ServerHandler.handlePacket(ServerHandler.java:164) [nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.network.RakNetInterface.process(RakNetInterface.java:66) [nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.network.Network.processInterfaces(Network.java:84) [nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.Server.tick(Server.java:1140) [nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.Server.tickProcessor(Server.java:919) [nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.Server.start(Server.java:896) [nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.Server.<init>(Server.java:578) [nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.Nukkit.main(Nukkit.java:112) [nukkit-1.0-SNAPSHOT.jar:?]
Caused by: java.lang.NullPointerException
        at java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:936) ~[?:1.8.0_232]
        at cn.nukkit.network.RakNetInterface.getNetworkLatency(RakNetInterface.java:90) ~[nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.Player.getPing(Player.java:1123) ~[nukkit-1.0-SNAPSHOT.jar:?]
        at me.kkdevs.broadcaster.Loader.replace(Loader.java:57) ~[?:?]
        at me.kkdevs.broadcaster.listener.PlayerQuitListener.onQuit(PlayerQuitListener.java:15) ~[?:?]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_232]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_232]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_232]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_232]
        at cn.nukkit.plugin.MethodEventExecutor.execute(MethodEventExecutor.java:29) ~[nukkit-1.0-SNAPSHOT.jar:?]
        ... 13 more
```
